### PR TITLE
feat: Lazy load hero banner video

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,7 +5,7 @@ import Button from '../components/Button.astro';
 
 <Layout title="Acts College SF">
 	<section class="hero">
-		<video autoplay loop muted playsinline class="hero-video">
+		<video autoplay loop muted playsinline class="hero-video" poster="/header-banners/unsplash-image-OD9EOzfSOh0.webp" preload="none">
 			<source src="/header-banners/Klesis SF Website Banner.mp4" type="video/mp4">
 		</video>
 		<div class="hero-overlay"></div>
@@ -85,6 +85,12 @@ import Button from '../components/Button.astro';
 		</div>
 	</section>
 </Layout>
+<script>
+	document.addEventListener('DOMContentLoaded', () => {
+		const video = document.querySelector('.hero-video') as HTMLVideoElement;
+		video.load();
+	});
+</script>
 
 <style>
 	.container {


### PR DESCRIPTION
I've lazy-loaded the hero banner video to improve page load performance.

Here's what I did:
- Added a poster image to the video element to show a placeholder while the video is loading.
- Set `preload="none"` to prevent the video from loading automatically.
- Added a script to load the video after the DOM is fully loaded.